### PR TITLE
Selectively compile LaTeX report based on path

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,10 +1,11 @@
 name: docs
 on:
     push:
-        branches:
-            - docs
         tags:
             - "v[0-9]+.[0-9]+.[0-9]+*"
+        # Run only when a file changes within the docs folder, ignored for tags
+        paths:
+            - docs/**
 
 env:
     # LaTeX root (main) filepath without file-extension


### PR DESCRIPTION
This commit Closes #18 by making any commit that changes the docs
directory trigger the docs GitHub Actions workflow to compile the LaTeX
report. It also removes docs branch trigger since this approach is
no longer used.

Summary of Changes:
- Replaced condition to trigger on docs branch with compilation when any
  file in the docs/ directory changes